### PR TITLE
feat: make container file systems read-only

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -51,7 +51,16 @@ export interface Configuration {
    */
   cnameRecords?: Record<string, string>;
 
-  openklant: OpenKlantConfiguration;
+  /**
+   * A list of databases that is created for
+   * the particular environment.
+   */
+  databases: string[];
+
+  /**
+   * Configuration for open klant
+   */
+  openklant?: OpenKlantConfiguration;
 }
 
 export interface OpenKlantConfiguration {
@@ -70,6 +79,7 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
     cnameRecords: {
       _b528d6157c2d9a369bf7d7812881d466: '_189b6977b0d0141d6cbb01e0ba1386e6.djqtsrsxkq.acm-validations.aws.',
     },
+    databases: Statics.databasesAcceptance,
     openklant: {
       image: 'maykinmedia/open-klant:2.1.0',
       logLevel: 'DEBUG',
@@ -85,6 +95,7 @@ const EnvironmentConfigurations: {[key:string]: Configuration} = {
     cnameRecords: {
       _762e893c9ea81e57b34ab11ed543256d: '_1c518863d978cddd100e65875b7c1136.djqtsrsxkq.acm-validations.aws.',
     },
+    databases: Statics.databasesProduction,
     openklant: {
       image: 'maykinmedia/open-klant:2.1.0',
       logLevel: 'INFO',

--- a/src/DatabaseStack.ts
+++ b/src/DatabaseStack.ts
@@ -9,9 +9,7 @@ import { Database } from './constructs/Database';
 import { CreateDatabasesFunction } from './custom-resources/create-databases/create-databases-function';
 import { Statics } from './Statics';
 
-interface DatabaseStackProps extends StackProps, Configurable {
-  databases?: string[];
-}
+interface DatabaseStackProps extends StackProps, Configurable {}
 
 export class DatabaseStack extends Stack {
 
@@ -30,8 +28,8 @@ export class DatabaseStack extends Stack {
       vpc: this.vpc.vpc,
     });
 
-    if (props.databases) {
-      this.createRequiredDatabasesIfNotExistent(props.databases);
+    if (props.configuration.databases) {
+      this.createRequiredDatabasesIfNotExistent(props.configuration.databases);
     }
 
   }

--- a/src/MainStack.ts
+++ b/src/MainStack.ts
@@ -50,6 +50,10 @@ export class MainStack extends Stack {
 
 
   private openKlantService(api: ApiGateway, platform: ContainerPlatform) {
+    if (!this.configuration.openklant) {
+      console.warn('No open-klant configuration provided. Skipping creation of open klant service!');
+      return;
+    }
     new OpenKlantService(this, 'open-klant', {
       hostedzone: this.hostedzone,
       cache: this.cache,

--- a/src/MijnServicesStage.ts
+++ b/src/MijnServicesStage.ts
@@ -4,7 +4,6 @@ import { Construct } from 'constructs';
 import { Configurable } from './Configuration';
 import { DatabaseStack } from './DatabaseStack';
 import { MainStack } from './MainStack';
-import { Statics } from './Statics';
 
 interface MijnServicesStageProps extends StageProps, Configurable {}
 
@@ -21,7 +20,6 @@ export class MijnServicesStage extends Stage {
     const databasestack = new DatabaseStack(this, 'database-stack', {
       env: props.configuration.deploymentEnvironment,
       configuration: props.configuration,
-      databases: Statics.databases,
     });
 
     /**

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -15,6 +15,8 @@ export class Statics {
   static readonly _ssmCertificateArn = `/${Statics.projectName}/internal/cloudfront/cert-arn`;
   static readonly _ssmDatabaseCredentials = `/${Statics.projectName}/internal/database/credentials`;
   static readonly _ssmOpenKlantCredentials = `/${Statics.projectName}/internal/open-klant/credentials`;
+  static readonly _ssmOpenNotificatiesCredentials = `/${Statics.projectName}/internal/open-notificaties/credentials`;
+  static readonly _ssmOpenZaakCredentials = `/${Statics.projectName}/internal/open-zaak/credentials`;
   static readonly _ssmDatabaseArn = `/${Statics.projectName}/internal/database/arn`;
   static readonly _ssmDatabaseHostname = `/${Statics.projectName}/internal/database/hostname`;
   static readonly _ssmDatabasePort = `/${Statics.projectName}/internal/database/post`;

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -25,13 +25,27 @@ export class Statics {
   // MARK: Databases
   static readonly defaultDatabaseName = 'postgres';
   static readonly databaseOpenKlant = 'open-klant';
+  static readonly databaseOpenNotificaties = 'open-notificaties';
+  static readonly databaseOpenZaak = 'open-zaak';
 
   /**
+   * PRODUCTION
    * List all databases that should be
    * present in a single array
    */
-  static readonly databases = [
+  static readonly databasesProduction = [
     Statics.databaseOpenKlant,
+  ];
+
+  /**
+   * ACCEPTANCE
+   * List all databases that should be
+   * present in a single array
+   */
+  static readonly databasesAcceptance = [
+    Statics.databaseOpenKlant,
+    Statics.databaseOpenNotificaties,
+    Statics.databaseOpenZaak,
   ];
 
   // MARK: Environments

--- a/src/constructs/ServiceFactory.ts
+++ b/src/constructs/ServiceFactory.ts
@@ -1,7 +1,7 @@
 import { Duration } from 'aws-cdk-lib';
 import { CfnIntegration, CfnRoute, HttpApi, HttpConnectionType, HttpIntegrationType, VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { Cluster, Compatibility, FargateService, FargateServiceProps, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
+import { Cluster, Compatibility, ContainerDefinition, FargateService, FargateServiceProps, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
 import { AccessPoint, FileSystem } from 'aws-cdk-lib/aws-efs';
 import { DnsRecordType, PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
@@ -89,6 +89,18 @@ export class ServiceFactory {
     }
 
     return service;
+  }
+
+  createEphemeralStorage(task: TaskDefinition, container: ContainerDefinition, name: string, ...mountpoints: string[]) {
+    task.addVolume({ name });
+    mountpoints.forEach(mountpoint => {
+      container.addMountPoints({
+        containerPath: mountpoint,
+        readOnly: false,
+        sourceVolume: name,
+      });
+    });
+
   }
 
   private createFileSytem(service: FargateService, options: CreateServiceOptions) {

--- a/src/constructs/ServiceFactory.ts
+++ b/src/constructs/ServiceFactory.ts
@@ -2,6 +2,7 @@ import { Duration } from 'aws-cdk-lib';
 import { CfnIntegration, CfnRoute, HttpApi, HttpConnectionType, HttpIntegrationType, VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, Compatibility, FargateService, FargateServiceProps, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
+import { AccessPoint, FileSystem } from 'aws-cdk-lib/aws-efs';
 import { DnsRecordType, PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
 
@@ -37,6 +38,13 @@ export interface CreateServiceOptions {
    * @default - No integration, route and servicediscovery are created
    */
   path?: string;
+  /**
+   * Configuration for mount paths in the filesystem.
+   * Provide a name and the container mounth path.
+   * A filesystem is automatically created.
+   * @default - no filesystem is created
+   */
+  filesystem?: Record<string, string>;
 }
 
 export class ServiceFactory {
@@ -76,8 +84,66 @@ export class ServiceFactory {
     if (options.path) {
       this.addRoute(service, options.path, options.id);
     }
+    if (options.filesystem) {
+      this.createFileSytem(service, options);
+    }
 
     return service;
+  }
+
+  private createFileSytem(service: FargateService, options: CreateServiceOptions) {
+    const privateFileSystemSecurityGroup = new SecurityGroup(this.scope, 'efs-security-group', {
+      vpc: this.props.cluster.vpc,
+    });
+
+    const fileSystem = new FileSystem(this.scope, 'esf-filesystem', {
+      encrypted: true,
+      vpc: this.props.cluster.vpc,
+      securityGroup: privateFileSystemSecurityGroup,
+    });
+
+    const fileSystemAccessPoint = new AccessPoint(this.scope, 'esf-access-point', {
+      fileSystem: fileSystem,
+
+      path: '/data',
+      createAcl: {
+        ownerGid: '1000',
+        ownerUid: '1000',
+        permissions: '755',
+      },
+      posixUser: {
+        uid: '1000',
+        gid: '1000',
+      },
+    });
+
+    const privateFileSystemConfig = {
+      authorizationConfig: {
+        accessPointId: fileSystemAccessPoint.accessPointId,
+        iam: 'ENABLED',
+      },
+      fileSystemId: fileSystem.fileSystemId,
+      transitEncryption: 'ENABLED',
+    };
+
+    const volumes = Object.entries(options.filesystem ?? {});
+    for (const volume of volumes) {
+      const name = volume[0];
+      const containerPath = volume[1];
+      service.taskDefinition.addVolume({
+        name: name,
+        efsVolumeConfiguration: privateFileSystemConfig,
+      });
+      service.taskDefinition.defaultContainer?.addMountPoints({
+        readOnly: false,
+        containerPath: containerPath,
+        sourceVolume: name,
+      });
+    }
+
+    service.connections.securityGroups.forEach(sg => {
+      privateFileSystemSecurityGroup.addIngressRule(sg, Port.NFS);
+    });
   }
 
   private addRoute(service: FargateService, path: string, id: string) {

--- a/src/constructs/ServiceFactory.ts
+++ b/src/constructs/ServiceFactory.ts
@@ -1,7 +1,7 @@
 import { Duration } from 'aws-cdk-lib';
 import { CfnIntegration, CfnRoute, HttpApi, HttpConnectionType, HttpIntegrationType, VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { Cluster, Compatibility, ContainerDefinition, FargateService, FargateServiceProps, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
+import { Cluster, Compatibility, ContainerDefinition, FargateService, FargateServiceProps, TaskDefinition, TaskDefinitionProps } from 'aws-cdk-lib/aws-ecs';
 import { AccessPoint, FileSystem } from 'aws-cdk-lib/aws-efs';
 import { DnsRecordType, PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
@@ -57,11 +57,12 @@ export class ServiceFactory {
     this.props = props;
   }
 
-  createTaskDefinition(id: string) {
+  createTaskDefinition(id: string, options?: Partial<TaskDefinitionProps>) {
     const task = new TaskDefinition(this.scope, `${id}-task`, {
       cpu: '256',
       memoryMiB: '512',
       compatibility: Compatibility.FARGATE,
+      ...options,
     });
     return task;
   }
@@ -91,8 +92,7 @@ export class ServiceFactory {
     return service;
   }
 
-  createEphemeralStorage(task: TaskDefinition, container: ContainerDefinition, name: string, ...mountpoints: string[]) {
-    task.addVolume({ name });
+  createEphemeralStorage(container: ContainerDefinition, name: string, ...mountpoints: string[]) {
     mountpoints.forEach(mountpoint => {
       container.addMountPoints({
         containerPath: mountpoint,

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -122,7 +122,7 @@ export class OpenKlantService extends Construct {
         streamPrefix: 'logs',
         logGroup: this.logs,
       }),
-      // readonlyRootFilesystem: true,
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
     });
@@ -155,7 +155,7 @@ export class OpenKlantService extends Construct {
           protocol: Protocol.TCP,
         },
       ],
-      // readonlyRootFilesystem: true,
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({
@@ -184,7 +184,7 @@ export class OpenKlantService extends Construct {
         command: ['CMD-SHELL', 'celery', '--app', 'openklant.celery'],
         interval: Duration.seconds(10),
       },
-      // readonlyRootFilesystem: true,
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -122,6 +122,7 @@ export class OpenKlantService extends Construct {
         streamPrefix: 'logs',
         logGroup: this.logs,
       }),
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
     });
@@ -154,6 +155,7 @@ export class OpenKlantService extends Construct {
           protocol: Protocol.TCP,
         },
       ],
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({
@@ -182,6 +184,7 @@ export class OpenKlantService extends Construct {
         command: ['CMD-SHELL', 'celery', '--app', 'openklant.celery'],
         interval: Duration.seconds(10),
       },
+      readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -122,7 +122,7 @@ export class OpenKlantService extends Construct {
         streamPrefix: 'logs',
         logGroup: this.logs,
       }),
-      readonlyRootFilesystem: true,
+      // readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
     });
@@ -155,7 +155,7 @@ export class OpenKlantService extends Construct {
           protocol: Protocol.TCP,
         },
       ],
-      readonlyRootFilesystem: true,
+      // readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({
@@ -184,7 +184,7 @@ export class OpenKlantService extends Construct {
         command: ['CMD-SHELL', 'celery', '--app', 'openklant.celery'],
         interval: Duration.seconds(10),
       },
-      readonlyRootFilesystem: true,
+      // readonlyRootFilesystem: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -178,7 +178,7 @@ export class OpenKlantService extends Construct {
 
   setupCeleryService() {
     const task = this.serviceFactory.createTaskDefinition('celery');
-    task.addContainer('celery', {
+    const container = task.addContainer('celery', {
       image: ContainerImage.fromRegistry(this.props.image),
       healthCheck: {
         command: ['CMD-SHELL', 'celery', '--app', 'openklant.celery'],
@@ -193,6 +193,7 @@ export class OpenKlantService extends Construct {
       }),
       command: ['/celery_worker.sh'],
     });
+    this.serviceFactory.createEphemeralStorage(task, container, 'temp', '/tmp');
     const service = this.serviceFactory.createService({
       task,
       path: undefined, // Not exposed service


### PR DESCRIPTION
- Add /tmp dir for celery container open-klant (uses init container to set writable permissions)
- Allow different database create lists for acceptance and production.
- Create open-notificaties en open-zaak databases for acceptance.