### PR TITLE
feat: move setup-configuration steps to separate services

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -255,6 +255,10 @@ export interface OpenKlantRegistrationServiceConfiguration {
     | 'partijperrol' // Convert the rol to a partij en store the partij id in the rol. Uses a dummy partij identificatie to keep each partij unique and for easy removal later on.
     | 'partijperroldry' // Without updating the rol in the Zaken api
   );
+  /**
+   * Flag to enable processing of notifications
+   */
+  enabled: boolean;
 }
 
 const EnvironmentConfigurations: { [key: string]: Configuration } = {
@@ -324,6 +328,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
         path: '/open-klant-registration-service-test/callback',
         roltypesToRegister: ['initiator'],
         strategy: 'partijperrol', // Unique partij per rol (of zaak dus)
+        enabled: true,
       },
       {
         cdkId: 'open-klant-registration-service-woweb',
@@ -333,6 +338,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
         path: '/open-klant-registration-service-woweb/callback',
         roltypesToRegister: ['initiator'],
         strategy: 'partijperrol', // Unique partij per rol (of zaak dus)
+        enabled: true,
       },
     ],
   },
@@ -363,6 +369,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
         roltypesToRegister: ['initiator'],
         strategy: 'partijperroldry', // Unique partij per rol (of zaak dus)
         // TODO change from dryrun later (but do not yet write results back to openzaak)
+        enabled: false,
       },
     ],
   },

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -276,19 +276,19 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
     databases: Statics.databasesAcceptance,
     databaseSnapshotRetentionDays: 10,
     openklant: {
-      image: 'maykinmedia/open-klant:2.3.0',
+      image: 'maykinmedia/open-klant:2.5.0',
       logLevel: 'DEBUG',
       debug: true,
     },
     openNotificaties: {
-      image: 'openzaak/open-notificaties:1.7.1',
-      rabbitMqImage: 'rabbitmq:4.0.3-alpine',
+      image: 'openzaak/open-notificaties:1.8.0',
+      rabbitMqImage: 'rabbitmq:4.0.5-alpine',
       logLevel: 'DEBUG',
       debug: true,
       persitNotifications: true,
     },
     openZaak: {
-      image: 'openzaak/open-zaak:1.15.0',
+      image: 'openzaak/open-zaak:1.17.0',
       logLevel: 'DEBUG',
       debug: true,
     },
@@ -356,7 +356,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
     databases: Statics.databasesProduction,
     databaseSnapshotRetentionDays: 35,
     openklant: {
-      image: 'maykinmedia/open-klant:2.3.0',
+      image: 'maykinmedia/open-klant:2.5.0',
       logLevel: 'INFO',
     },
     openKlantRegistrationServices: [

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -292,33 +292,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
       logLevel: 'DEBUG',
       debug: true,
     },
-    outputManagementComponents: [
-      {
-        cdkId: 'test-omc',
-        path: 'test-omc', // Without /
-        image: 'worthnl/notifynl-omc:1.11.3',
-        logLevel: 'DEBUG',
-        debug: true,
-        mode: 'Development',
-        openKlantUrl: 'mijn-services.accp.nijmegen.nl/open-klant/klantinteracties/api/v1',
-        zakenApiUrl: 'mijn-services.accp.nijmegen.nl/open-zaak/zaken/api/v1',
-        notificatiesApiUrl: 'mijn-services.accp.nijmegen.nl/open-notificaties/api/v1',
-        zgwTokenInformation: {
-          audience: '', // This must be empty for the token to start working... no clue as to why.
-          issuer: 'OMC',
-          userId: 'OMC',
-          username: 'OMC',
-        },
-        templates: {
-          zaakCreateEmail: 'e2915eea-de25-48f5-8292-879d369060fa',
-          zaakUpdateEmail: 'e868044f-4a30-42c9-b1bf-8ad95ec2a6b8',
-          zaakCloseEmail: '14cebdee-a179-4e0e-b7de-c660fdd47c57',
-          zaakCreateSms: 'b17f8f7a-6992-466d-8248-3f1c077610ce',
-          zaakUpdateSms: '0ff5f21a-2af1-4fd4-8080-45cff34e0df7',
-          zaakCloseSms: 'ac885f24-09d8-4702-845f-2f53cd045790',
-        },
-      },
-    ],
+    outputManagementComponents: undefined,
     openKlantRegistrationServices: [
       {
         cdkId: 'open-klant-registration-service-test',

--- a/src/constructs/ContainerPlatform.ts
+++ b/src/constructs/ContainerPlatform.ts
@@ -1,6 +1,8 @@
+import { Stack } from 'aws-cdk-lib';
 import { VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ExecuteCommandLogging } from 'aws-cdk-lib/aws-ecs';
+import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
@@ -49,6 +51,46 @@ export class ContainerPlatform extends Construct {
       encryptionKey: key,
       retention: RetentionDays.ONE_YEAR, // Also audit trail
     });
+
+
+    const region = Stack.of(this).region;
+    const account = Stack.of(this).account;
+    key.addToResourcePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal(`logs.${region}.amazonaws.com`)],
+      actions: [
+        'kms:Decrypt',
+        'kms:DescribeKey',
+        'kms:Encrypt',
+        'kms:ReEncrypt*',
+        'kms:GenerateDataKey*',
+      ],
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'aws:RequestedRegion': region,
+          'aws:PrincipalAccount': account,
+        },
+      },
+    }));
+    key.addToResourcePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal('ecs.amazonaws.com')],
+      actions: [
+        'kms:Decrypt',
+        'kms:DescribeKey',
+        'kms:Encrypt',
+        'kms:ReEncrypt*',
+        'kms:GenerateDataKey*',
+      ],
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'aws:RequestedRegion': region,
+          'aws:PrincipalAccount': account,
+        },
+      },
+    }));
 
     this.cluster = new Cluster(this, 'cluster', {
       vpc: props.vpc,

--- a/src/constructs/ContainerPlatform.ts
+++ b/src/constructs/ContainerPlatform.ts
@@ -1,6 +1,6 @@
 import { VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { Cluster, ExecuteCommandLogging } from 'aws-cdk-lib/aws-ecs';
+import { Cluster } from 'aws-cdk-lib/aws-ecs';
 import { PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
 
@@ -39,9 +39,6 @@ export class ContainerPlatform extends Construct {
 
     this.cluster = new Cluster(this, 'cluster', {
       vpc: props.vpc,
-      executeCommandConfiguration: {
-        logging: ExecuteCommandLogging.DEFAULT,
-      },
     });
 
   }

--- a/src/constructs/ContainerPlatform.ts
+++ b/src/constructs/ContainerPlatform.ts
@@ -1,13 +1,8 @@
-import { Stack } from 'aws-cdk-lib';
 import { VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
 import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Cluster, ExecuteCommandLogging } from 'aws-cdk-lib/aws-ecs';
-import { Effect, PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Key } from 'aws-cdk-lib/aws-kms';
-import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
-import { Statics } from '../Statics';
 
 export interface ContainerPlatformProps {
   /**
@@ -42,65 +37,10 @@ export class ContainerPlatform extends Construct {
       securityGroups: [this.vpcLinkSecurityGroup],
     });
 
-
-    const key = new Key(this, 'cluster-exec-logs-key', {
-      description: 'Key for encrypting cluster exec commands and logs',
-      alias: `${Statics.projectName}/cluster-exec`,
-    });
-    const logs = new LogGroup(this, 'cluster-exec-logs', {
-      encryptionKey: key,
-      retention: RetentionDays.ONE_YEAR, // Also audit trail
-    });
-
-
-    const region = Stack.of(this).region;
-    const account = Stack.of(this).account;
-    key.addToResourcePolicy(new PolicyStatement({
-      effect: Effect.ALLOW,
-      principals: [new ServicePrincipal(`logs.${region}.amazonaws.com`)],
-      actions: [
-        'kms:Decrypt',
-        'kms:DescribeKey',
-        'kms:Encrypt',
-        'kms:ReEncrypt*',
-        'kms:GenerateDataKey*',
-      ],
-      resources: ['*'],
-      conditions: {
-        StringEquals: {
-          'aws:RequestedRegion': region,
-          'aws:PrincipalAccount': account,
-        },
-      },
-    }));
-    key.addToResourcePolicy(new PolicyStatement({
-      effect: Effect.ALLOW,
-      principals: [new ServicePrincipal('ecs.amazonaws.com')],
-      actions: [
-        'kms:Decrypt',
-        'kms:DescribeKey',
-        'kms:Encrypt',
-        'kms:ReEncrypt*',
-        'kms:GenerateDataKey*',
-      ],
-      resources: ['*'],
-      conditions: {
-        StringEquals: {
-          'aws:RequestedRegion': region,
-          'aws:PrincipalAccount': account,
-        },
-      },
-    }));
-
     this.cluster = new Cluster(this, 'cluster', {
       vpc: props.vpc,
       executeCommandConfiguration: {
-        kmsKey: key,
-        logConfiguration: {
-          cloudWatchLogGroup: logs,
-          cloudWatchEncryptionEnabled: true,
-        },
-        logging: ExecuteCommandLogging.OVERRIDE,
+        logging: ExecuteCommandLogging.DEFAULT,
       },
     });
 

--- a/src/containers/open-notificaties/Dockerfile
+++ b/src/containers/open-notificaties/Dockerfile
@@ -1,0 +1,20 @@
+# Very simple build file
+# Take tha base image we are running anyway and add the configuration file
+# Set the entrypoint to a script that:
+# 1. Resolves env variables in the YAML file
+# 2. Calles the setup_configuration.sh script (provided by container)
+ARG OPEN_NOTIFICATIES_IMAGE=openzaak/open-notificaties:latest
+FROM ${OPEN_NOTIFICATIES_IMAGE}
+COPY ./setup_configuration.yaml /setup_configuration.yaml 
+COPY ./entrypoint.sh /custom_entrypoint.sh
+CMD '/custom_entrypoint.sh'
+
+
+
+# Required env vars
+#OPEN_ZAAK_BASE_URL=https://mijn-services.accp.nijmegen.nl/open-zaak
+#OPENNOTIFICATIES_DOMAIN=mijn-services.accp.nijmegen.nl
+#NOTIF_OPENZAAK_CLIENT_ID # Notificaties -> open zaak
+#NOTIF_OPENZAAK_SECRET # Notificaties -> open zaak
+#OPENZAAK_NOTIF_CLIENT_ID # Open-zaak -> notificaties
+#OPENZAAK_NOTIF_SECRET # Open-zaak -> notificaties

--- a/src/containers/open-notificaties/entrypoint.sh
+++ b/src/containers/open-notificaties/entrypoint.sh
@@ -2,7 +2,6 @@
 echo "Replacing environment variables in yaml file and write it to a writable location"
 mkdir -p /app/setup_configuration
 envsubst < /setup_configuration.yaml > /app/setup_configuration/data.yaml
-cat /app/setup_configuration/data.yaml
 
 # Call the setup configuration script
 echo "Running setup configuration script from base image"

--- a/src/containers/open-notificaties/entrypoint.sh
+++ b/src/containers/open-notificaties/entrypoint.sh
@@ -1,0 +1,9 @@
+# Replacing environment variables in yaml file and write it to a writable location
+echo "Replacing environment variables in yaml file and write it to a writable location"
+mkdir -p /app/setup_configuration
+envsubst < /setup_configuration.yaml > /app/setup_configuration/data.yaml
+cat /app/setup_configuration/data.yaml
+
+# Call the setup configuration script
+echo "Running setup configuration script from base image"
+/setup_configuration.sh

--- a/src/containers/open-notificaties/setup_configuration.yaml
+++ b/src/containers/open-notificaties/setup_configuration.yaml
@@ -1,0 +1,98 @@
+# For these things we do not have a default configuration
+oidc_db_config_enable: false # Configured using UI
+sites_config_enable: false # Not configured
+notifications_config_enable: false # Default values are ok
+notifications_abonnementen_config_enable: false # No default subscriptions
+
+
+# Setup how open-notificaties connects to other services
+zgw_consumers_config_enable: True 
+zgw_consumers:
+  services:
+    - identifier: autorisaties-api
+      label: Autorisaties API
+      api_root: ${OPEN_ZAAK_BASE_URL}/autorisaties/api/v1/
+      api_type: ac
+      auth_type: zgw
+      client_id: ${NOTIF_OPENZAAK_CLIENT_ID}
+      secret: ${NOTIF_OPENZAAK_SECRET}
+      user_id: ${NOTIF_OPENZAAK_CLIENT_ID}
+      user_representation: ${NOTIF_OPENZAAK_CLIENT_ID}
+    - identifier: notificaties-api
+      label: Notificaties API
+      api_root: https://${OPENNOTIFICATIES_DOMAIN}/api/v1/
+      api_type: nrc
+      auth_type: zgw
+      client_id: ${OPENZAAK_NOTIF_CLIENT_ID}
+      secret: ${OPENZAAK_NOTIF_SECRET}
+      user_id: ${OPENZAAK_NOTIF_CLIENT_ID}
+      user_representation: ${OPENZAAK_NOTIF_CLIENT_ID}
+
+
+# Setup how other services authenticate at open-notificaties
+vng_api_common_credentials_config_enable: True 
+vng_api_common_credentials:
+  items:
+    # Credentials for Open Zaak to be able to make requests to Open Notificaties
+    - identifier: ${OPENZAAK_NOTIF_CLIENT_ID}
+      secret: ${OPENZAAK_NOTIF_SECRET}
+    # Credentials for Open Notificaties, required for autorisaties subscription
+    - identifier: ${NOTIF_OPENZAAK_CLIENT_ID}
+      secret: ${NOTIF_OPENZAAK_SECRET}
+
+
+# Configure Open Notificaties to make use of Open Zaak's Autorisaties API
+autorisaties_api_config_enable: True
+autorisaties_api:
+  authorizations_api_service_identifier: autorisaties-api
+
+
+# Setup the channels required for basic events
+notifications_kanalen_config_enable: true 
+notifications_kanalen_config:
+  items:
+    - naam: autorisaties
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/autorisaties
+      filters: []
+    - naam: besluittypen
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/besluittypen
+      filters:
+        - catalogus
+    - naam: informatieobjecttypen
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/informatieobjecttypen
+      filters:
+        - catalogus
+    - naam: zaaktypen
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/zaaktypen
+      filters:
+        - catalogus
+    - naam: zaken
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/zaken
+      filters:
+        - bronorganisatie
+        - zaaktype
+        - vertrouwelijkheidaanduiding
+    - naam: documenten
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/documenten
+      filters:
+        - bronorganisatie
+        - informatieobjecttype
+        - vertrouwelijkheidaanduiding
+    - naam: besluiten
+      documentatie_link: ${OPEN_ZAAK_BASE_URL}/ref/kanalen/#/besluiten
+      filters:
+        - verantwoordelijke_organisatie
+        - besluittype
+
+
+# Setup default subscriptions
+notifications_subscriptions_config_enable: true
+notifications_subscriptions_config:
+  items:
+    - identifier: autorisaties-subscription
+      callback_url: https://${OPENNOTIFICATIES_DOMAIN}/api/v1/callbacks
+      client_id: ${OPENZAAK_NOTIF_CLIENT_ID}
+      secret: ${OPENZAAK_NOTIF_SECRET}
+      uuid: 0f616bfd-aacc-4d85-a140-2af17a56217b
+      channels:
+        - autorisaties

--- a/src/containers/open-zaak/Dockerfile
+++ b/src/containers/open-zaak/Dockerfile
@@ -1,0 +1,10 @@
+# Very simple build file
+# Take tha base image we are running anyway and add the configuration file
+# Set the entrypoint to a script that:
+# 1. Resolves env variables in the YAML file
+# 2. Calles the setup_configuration.sh script (provided by container)
+ARG OPEN_ZAAK_IMAGE
+FROM ${OPEN_ZAAK_IMAGE}
+COPY ./setup_configuration.yaml /setup_configuration.yaml 
+COPY ./entrypoint.sh /custom_entrypoint.sh
+ENTRYPOINT ['/custom_entrypoint.sh']

--- a/src/containers/open-zaak/Dockerfile
+++ b/src/containers/open-zaak/Dockerfile
@@ -8,3 +8,11 @@ FROM ${OPEN_ZAAK_IMAGE}
 COPY ./setup_configuration.yaml /setup_configuration.yaml 
 COPY ./entrypoint.sh /custom_entrypoint.sh
 CMD '/custom_entrypoint.sh'
+
+
+# Required env vars for config to work
+# NOTIF_API_ROOT
+# OPENZAAK_NOTIF_CLIENT_ID
+# OPENZAAK_NOTIF_SECRET
+# NOTIF_OPENZAAK_CLIENT_ID
+# NOTIF_OPENZAAK_SECRET

--- a/src/containers/open-zaak/Dockerfile
+++ b/src/containers/open-zaak/Dockerfile
@@ -3,8 +3,8 @@
 # Set the entrypoint to a script that:
 # 1. Resolves env variables in the YAML file
 # 2. Calles the setup_configuration.sh script (provided by container)
-ARG OPEN_ZAAK_IMAGE
+ARG OPEN_ZAAK_IMAGE=openzaak/open-zaak:latest
 FROM ${OPEN_ZAAK_IMAGE}
 COPY ./setup_configuration.yaml /setup_configuration.yaml 
 COPY ./entrypoint.sh /custom_entrypoint.sh
-ENTRYPOINT ['/custom_entrypoint.sh']
+CMD '/custom_entrypoint.sh'

--- a/src/containers/open-zaak/entrypoint.sh
+++ b/src/containers/open-zaak/entrypoint.sh
@@ -3,3 +3,6 @@ envsubst < setup_configuration.yaml > /app/setup_configuration/data.yaml
 
 # Call the setup configuration script
 /setup_configuration.sh
+
+# Setup kanalen that we are expecting
+python src/manage.py register_kanalen

--- a/src/containers/open-zaak/entrypoint.sh
+++ b/src/containers/open-zaak/entrypoint.sh
@@ -1,0 +1,5 @@
+# Replace environment variables in yaml file and write it to a writable location
+envsubst < setup_configuration.yaml > /app/setup_configuration/data.yaml
+
+# Call the setup configuration script
+/setup_configuration.sh

--- a/src/containers/open-zaak/entrypoint.sh
+++ b/src/containers/open-zaak/entrypoint.sh
@@ -1,8 +1,9 @@
-# Replace environment variables in yaml file and write it to a writable location
-envsubst < setup_configuration.yaml > /app/setup_configuration/data.yaml
+# Replacing environment variables in yaml file and write it to a writable location
+echo "Replacing environment variables in yaml file and write it to a writable location"
+mkdir -p /app/setup_configuration
+envsubst < /setup_configuration.yaml > /app/setup_configuration/data.yaml
+cat /app/setup_configuration/data.yaml
 
 # Call the setup configuration script
+echo "Running setup configuration script from base image"
 /setup_configuration.sh
-
-# Setup kanalen that we are expecting
-python src/manage.py register_kanalen

--- a/src/containers/open-zaak/entrypoint.sh
+++ b/src/containers/open-zaak/entrypoint.sh
@@ -5,5 +5,4 @@ envsubst < /setup_configuration.yaml > /app/setup_configuration/data.yaml
 
 # Call the setup configuration script
 echo "Running setup configuration script from base image"
-# cat /app/setup_configuration/data.yaml
 /setup_configuration.sh

--- a/src/containers/open-zaak/entrypoint.sh
+++ b/src/containers/open-zaak/entrypoint.sh
@@ -2,8 +2,8 @@
 echo "Replacing environment variables in yaml file and write it to a writable location"
 mkdir -p /app/setup_configuration
 envsubst < /setup_configuration.yaml > /app/setup_configuration/data.yaml
-cat /app/setup_configuration/data.yaml
 
 # Call the setup configuration script
 echo "Running setup configuration script from base image"
+# cat /app/setup_configuration/data.yaml
 /setup_configuration.sh

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -1,0 +1,69 @@
+sites_config_enable: true
+sites_config:
+  items:
+  - domain: example.com
+    name: Example site
+
+zgw_consumers_config_enable: true
+zgw_consumers:
+  services:
+  - identifier: notifications-api
+    label: Notificaties API
+    api_root: http://notificaties.local/api/v1/
+    api_connection_check_path: notificaties
+    api_type: nrc
+    auth_type: api_key
+    header_key: Authorization
+    header_value: Token ba9d233e95e04c4a8a661a27daffe7c9bd019067
+
+  - identifier: selectielijst-api
+    label: Selectielijst API
+    api_root: https://selectielijst.local/api/v1/
+    api_connection_check_path: selectielijst
+    api_type: orc
+    auth_type: api_key
+    header_key: Authorization
+    header_value: Token dRlyhrXpcJVjZ0Hvt5dGf2t0dSQctAgkmfAHvZHh
+
+notifications_config_enable: true
+notifications_config:
+  notifications_api_service_identifier: notifications-api
+  notification_delivery_max_retries: 1
+  notification_delivery_retry_backoff: 2
+  notification_delivery_retry_backoff_max: 3
+
+openzaak_selectielijst_config_enable: true
+openzaak_selectielijst_config:
+  selectielijst_api_service_identifier: selectielijst-api
+  allowed_years:
+    - 2025
+    - 2026
+    - 2027
+    - 2028
+  default_year: 2025
+
+vng_api_common_credentials_config_enable: true
+vng_api_common_credentials:
+  items:
+  - identifier: user-id
+    secret: super-secret
+
+vng_api_common_applicaties_config_enable: true
+vng_api_common_applicaties:
+  items:
+  - uuid: 78591bab-9a00-4887-849c-53b21a67782f
+    client_ids:
+    - user-id
+    label: applicatie
+    heeft_alle_autorisaties: true
+
+oidc_db_config_enable: true
+oidc_db_config_admin_auth:
+  items:
+    - identifier: admin-oidc
+      oidc_rp_client_id: client-id
+      oidc_rp_client_secret: secret
+      endpoint_config:
+        oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+        oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+        oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -4,13 +4,13 @@
 
 
 # No default config for the following:
-sites_config_enable: false # I dont think we need this
-notifications_config_enable: false # Configure notification retry (defaults are ok)
-openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperken?
-oidc_db_config_enable: false # This is done in the UI
+# sites_config_enable: false # I dont think we need this
+# notifications_config_enable: false # Configure notification retry (defaults are ok)
+# openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperken?
+# oidc_db_config_enable: false # This is done in the UI
 
 # Define how to connect to other servies from open-zaak
-zgw_consumers_config_enable: True
+zgw_consumers_config_enable: true
 zgw_consumers:
   services:
     # Default connection to selectielijst (no auth)
@@ -34,7 +34,7 @@ zgw_consumers:
 
 
 # Defines how others authenticate at this open-zaak
-vng_api_common_credentials_config_enable: True
+vng_api_common_credentials_config_enable: true
 vng_api_common_credentials:
   items:
   - identifier: ${NOTIF_OPENZAAK_CLIENT_ID}
@@ -42,7 +42,7 @@ vng_api_common_credentials:
 
 
 # Defines default authorizations (based on client id)
-vng_api_common_applicaties_config_enable: True
+vng_api_common_applicaties_config_enable: true
 vng_api_common_applicaties:
   items:
   - uuid: 78591bab-9a00-4887-849c-53b21a67782f # Give permissions to default credential pairs for connections between open-zaak <-> open-notifications

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -2,12 +2,14 @@
 # Documentation on how this file works can be found here:
 # https://zgw-consumers.readthedocs.io/en/latest/setup_config.html
 
-sites_config_enable: false # I dont think we need this
-# sites_config:
-#   items:
-#   - domain: ${}
-#     name: 
 
+# No default config for the following:
+sites_config_enable: false # I dont think we need this
+notifications_config_enable: false # Configure notification retry (defaults are ok)
+openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperken?
+oidc_db_config_enable: false # This is done in the UI
+
+# Define how to connect to other servies from open-zaak
 zgw_consumers_config_enable: true
 zgw_consumers:
   services:
@@ -21,52 +23,33 @@ zgw_consumers:
     # Reference our notifications API
     - identifier: notifications-api
       label: Notificaties API
-      api_root: ${OPEN_NOTIFICATIES_API_URL}
+      api_root: ${NOTIF_API_ROOT}
       api_connection_check_path: notificaties
       api_type: nrc
-      auth_type: api_key
-      header_key: Authorization
-      header_value: Token ${OPEN_NOTIFICATIES_API_KEY}
+      auth_type: zgw
+      client_id: ${OPENZAAK_NOTIF_CLIENT_ID}
+      secret: ${OPENZAAK_NOTIF_SECRET}
+      user_id: ${OPENZAAK_NOTIF_CLIENT_ID}
+      user_representation: ${OPENZAAK_NOTIF_CLIENT_ID}
 
-notifications_config_enable: false # Configure notification retry (defaults are ok)
-# notifications_config:
-#   notifications_api_service_identifier: notifications-api
-#   notification_delivery_max_retries: 1
-#   notification_delivery_retry_backoff: 2
-#   notification_delivery_retry_backoff_max: 3
 
-openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperken?
-# openzaak_selectielijst_config:
-#   selectielijst_api_service_identifier: selectielijst-api
-#   allowed_years:
-#     - 2025
-#     - 2026
-#     - 2027
-#     - 2028
-#   default_year: 2025
-
-vng_api_common_credentials_config_enable: true # Super user setup?
+# Defines how others authenticate at this open-zaak
+vng_api_common_credentials_config_enable: true
 vng_api_common_credentials:
   items:
-  - identifier: user-id
-    secret: super-secret
+  - identifier: ${NOTIF_OPENZAAK_CLIENT_ID}
+    secret: ${NOTIF_OPENZAAK_SECRET}
 
-vng_api_common_applicaties_config_enable: false # Geen idee wat dit doet
-# vng_api_common_applicaties:
-#   items:
-#   - uuid: 78591bab-9a00-4887-849c-53b21a67782f
-#     client_ids:
-#     - user-id
-#     label: applicatie
-#     heeft_alle_autorisaties: true
 
-oidc_db_config_enable: false # This is done in the UI
-# oidc_db_config_admin_auth:
-#   items:
-#     - identifier: admin-oidc
-#       oidc_rp_client_id: client-id
-#       oidc_rp_client_secret: secret
-#       endpoint_config:
-#         oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
-#         oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
-#         oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+# Defines default authorizations (based on client id)
+vng_api_common_applicaties_config_enable: true
+vng_api_common_applicaties:
+  items:
+  - uuid: 78591bab-9a00-4887-849c-53b21a67782f # Give permissions to default credential pairs for connections between open-zaak <-> open-notifications
+    client_ids:
+    - ${NOTIF_OPENZAAK_CLIENT_ID}
+    - ${OPENZAAK_NOTIF_CLIENT_ID}
+    label: applicatie
+    heeft_alle_autorisaties: true
+
+

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -21,12 +21,12 @@ zgw_consumers:
     # Reference our notifications API
     - identifier: notifications-api
       label: Notificaties API
-      api_root: http://notificaties.local/api/v1/
+      api_root: ${OPEN_NOTIFICATIES_API_URL}
       api_connection_check_path: notificaties
       api_type: nrc
       auth_type: api_key
       header_key: Authorization
-      header_value: Token ba9d233e95e04c4a8a661a27daffe7c9bd019067
+      header_value: Token ${OPEN_NOTIFICATIES_API_KEY}
 
 notifications_config_enable: false # Configure notification retry (defaults are ok)
 # notifications_config:

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -1,69 +1,72 @@
-sites_config_enable: true
-sites_config:
-  items:
-  - domain: example.com
-    name: Example site
+
+# Documentation on how this file works can be found here:
+# https://zgw-consumers.readthedocs.io/en/latest/setup_config.html
+
+sites_config_enable: false # I dont think we need this
+# sites_config:
+#   items:
+#   - domain: ${}
+#     name: 
 
 zgw_consumers_config_enable: true
 zgw_consumers:
   services:
-  - identifier: notifications-api
-    label: Notificaties API
-    api_root: http://notificaties.local/api/v1/
-    api_connection_check_path: notificaties
-    api_type: nrc
-    auth_type: api_key
-    header_key: Authorization
-    header_value: Token ba9d233e95e04c4a8a661a27daffe7c9bd019067
+    # Default connection to selectielijst (no auth)
+    - identifier: selectielijst-api
+      label: Selectielijst API
+      api_root: https://selectielijst.local/api/v1/
+      api_connection_check_path: selectielijst
+      api_type: orc
+      auth_type: no_auth
+    # Reference our notifications API
+    - identifier: notifications-api
+      label: Notificaties API
+      api_root: http://notificaties.local/api/v1/
+      api_connection_check_path: notificaties
+      api_type: nrc
+      auth_type: api_key
+      header_key: Authorization
+      header_value: Token ba9d233e95e04c4a8a661a27daffe7c9bd019067
 
-  - identifier: selectielijst-api
-    label: Selectielijst API
-    api_root: https://selectielijst.local/api/v1/
-    api_connection_check_path: selectielijst
-    api_type: orc
-    auth_type: api_key
-    header_key: Authorization
-    header_value: Token dRlyhrXpcJVjZ0Hvt5dGf2t0dSQctAgkmfAHvZHh
+notifications_config_enable: false # Configure notification retry (defaults are ok)
+# notifications_config:
+#   notifications_api_service_identifier: notifications-api
+#   notification_delivery_max_retries: 1
+#   notification_delivery_retry_backoff: 2
+#   notification_delivery_retry_backoff_max: 3
 
-notifications_config_enable: true
-notifications_config:
-  notifications_api_service_identifier: notifications-api
-  notification_delivery_max_retries: 1
-  notification_delivery_retry_backoff: 2
-  notification_delivery_retry_backoff_max: 3
+openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperken?
+# openzaak_selectielijst_config:
+#   selectielijst_api_service_identifier: selectielijst-api
+#   allowed_years:
+#     - 2025
+#     - 2026
+#     - 2027
+#     - 2028
+#   default_year: 2025
 
-openzaak_selectielijst_config_enable: true
-openzaak_selectielijst_config:
-  selectielijst_api_service_identifier: selectielijst-api
-  allowed_years:
-    - 2025
-    - 2026
-    - 2027
-    - 2028
-  default_year: 2025
-
-vng_api_common_credentials_config_enable: true
+vng_api_common_credentials_config_enable: true # Super user setup?
 vng_api_common_credentials:
   items:
   - identifier: user-id
     secret: super-secret
 
-vng_api_common_applicaties_config_enable: true
-vng_api_common_applicaties:
-  items:
-  - uuid: 78591bab-9a00-4887-849c-53b21a67782f
-    client_ids:
-    - user-id
-    label: applicatie
-    heeft_alle_autorisaties: true
+vng_api_common_applicaties_config_enable: false # Geen idee wat dit doet
+# vng_api_common_applicaties:
+#   items:
+#   - uuid: 78591bab-9a00-4887-849c-53b21a67782f
+#     client_ids:
+#     - user-id
+#     label: applicatie
+#     heeft_alle_autorisaties: true
 
-oidc_db_config_enable: true
-oidc_db_config_admin_auth:
-  items:
-    - identifier: admin-oidc
-      oidc_rp_client_id: client-id
-      oidc_rp_client_secret: secret
-      endpoint_config:
-        oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
-        oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
-        oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+oidc_db_config_enable: false # This is done in the UI
+# oidc_db_config_admin_auth:
+#   items:
+#     - identifier: admin-oidc
+#       oidc_rp_client_id: client-id
+#       oidc_rp_client_secret: secret
+#       endpoint_config:
+#         oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+#         oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+#         oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/src/containers/open-zaak/setup_configuration.yaml
+++ b/src/containers/open-zaak/setup_configuration.yaml
@@ -10,7 +10,7 @@ openzaak_selectielijst_config_enable: false # Geen idee of we dit willen beperke
 oidc_db_config_enable: false # This is done in the UI
 
 # Define how to connect to other servies from open-zaak
-zgw_consumers_config_enable: true
+zgw_consumers_config_enable: True
 zgw_consumers:
   services:
     # Default connection to selectielijst (no auth)
@@ -34,7 +34,7 @@ zgw_consumers:
 
 
 # Defines how others authenticate at this open-zaak
-vng_api_common_credentials_config_enable: true
+vng_api_common_credentials_config_enable: True
 vng_api_common_credentials:
   items:
   - identifier: ${NOTIF_OPENZAAK_CLIENT_ID}
@@ -42,7 +42,7 @@ vng_api_common_credentials:
 
 
 # Defines default authorizations (based on client id)
-vng_api_common_applicaties_config_enable: true
+vng_api_common_applicaties_config_enable: True
 vng_api_common_applicaties:
   items:
   - uuid: 78591bab-9a00-4887-849c-53b21a67782f # Give permissions to default credential pairs for connections between open-zaak <-> open-notifications

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -1,6 +1,7 @@
 import { Duration, Token } from 'aws-cdk-lib';
 import { ISecurityGroup, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { AwsLogDriver, ContainerDependencyCondition, ContainerImage, Protocol, Secret } from 'aws-cdk-lib/aws-ecs';
+import { AwsLogDriver, ContainerDependencyCondition, ContainerImage, LaunchType, Protocol, Secret } from 'aws-cdk-lib/aws-ecs';
+import { EcsTask } from 'aws-cdk-lib/aws-events-targets';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -51,6 +52,7 @@ export class OpenKlantService extends Construct {
     this.setupInitalization();
     this.setupService();
     this.setupCeleryService();
+    this.setupConfigurationTask();
   }
 
   private getEnvironmentConfiguration() {
@@ -68,7 +70,7 @@ export class OpenKlantService extends Construct {
       ALLOWED_HOSTS: '*',
       CACHE_DEFAULT: cacheHost + this.props.cacheDatabaseIndex,
       CACHE_AXES: cacheHost + this.props.cacheDatabaseIndex,
-      SUBPATH: '/'+this.props.path,
+      SUBPATH: '/' + this.props.path,
       IS_HTTPS: 'True',
       UWSGI_PORT: this.props.service.port.toString(),
 
@@ -262,5 +264,40 @@ export class OpenKlantService extends Construct {
     this.openKlantCredentials.grantRead(role);
   }
 
+
+  private setupConfigurationTask() {
+    const task = this.serviceFactory.createTaskDefinition('setup-configuration');
+    task.addContainer('setup-configuration-init', {
+      image: ContainerImage.fromRegistry(this.props.image),
+      healthCheck: {
+        command: ['CMD-SHELL', 'exit 0'], // Not sure what to check when executing a single script
+        startPeriod: Duration.seconds(30), // Give the script an inital 30 seconds to run before starting the health check
+      },
+      // Note: use env vars in combinations with the below command https://stackoverflow.com/questions/26963444/django-create-superuser-from-batch-file
+      // Note command can only run once: 'CommandError: Error: That gebruikersnaam is already taken.'
+      command: ['python', 'src/manage.py', 'createsuperuser', '--no-input', '--skip-checks'],
+      portMappings: [],
+      logging: new AwsLogDriver({
+        streamPrefix: 'init',
+        logGroup: this.logs,
+      }),
+      readonlyRootFilesystem: true,
+      secrets: this.getSecretConfiguration(),
+      environment: this.getEnvironmentConfiguration(),
+    });
+
+    const standalone = new EcsTask({
+      cluster: this.props.service.cluster,
+      taskDefinition: task,
+      taskCount: 1,
+      launchType: LaunchType.FARGATE,
+    });
+
+    if (!standalone.securityGroups) {
+      throw Error('Expected security groups to be set for standalone task!');
+    }
+    this.setupConnectivity('setup-configuration-init', standalone?.securityGroups);
+    this.allowAccessToSecrets(task.executionRole!);
+  }
 
 }

--- a/src/services/OpenKlant.ts
+++ b/src/services/OpenKlant.ts
@@ -1,6 +1,6 @@
 import { Duration, Token } from 'aws-cdk-lib';
 import { ISecurityGroup, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { AwsLogDriver, ContainerDependencyCondition, ContainerImage, Protocol, Secret } from 'aws-cdk-lib/aws-ecs';
+import { AwsLogDriver, ContainerImage, Protocol, Secret } from 'aws-cdk-lib/aws-ecs';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -201,22 +201,7 @@ export class OpenKlantService extends Construct {
     });
     this.serviceFactory.attachEphemeralStorage(container, VOLUME_NAME, '/tmp');
 
-    // Set the correct rights for the /tmp dir using a init container
-    const initContainer = task.addContainer('init-storage', {
-      image: ContainerImage.fromRegistry('alpine:latest'),
-      entryPoint: ['sh', '-c'],
-      command: ['chmod 0777 /tmp'],
-      readonlyRootFilesystem: true,
-      essential: false, // exit after running
-      logging: new AwsLogDriver({
-        streamPrefix: 'init-storage',
-      }),
-    });
-    container.addContainerDependencies({
-      container: initContainer,
-      condition: ContainerDependencyCondition.SUCCESS,
-    });
-    this.serviceFactory.attachEphemeralStorage(initContainer, VOLUME_NAME, '/tmp');
+    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, container, '/tmp');
 
     // Construct the service and setup conectivity and secrets access
     const service = this.serviceFactory.createService({

--- a/src/services/OpenKlantRegistrationService/Notes.md
+++ b/src/services/OpenKlantRegistrationService/Notes.md
@@ -1,0 +1,5 @@
+# Notes
+
+Na de update van open klant naar de laatste versie zijn er een aantal dingen om rekening mee te houden:
+- Het soortDigitaalAdress in het digitaal adres veld is aangepast naar een enum, heeft dit gevolgen voor het OMC?
+- Telefoonnummer wordt volgens een regex gevalideerd dit moeten we in het formulier al recht gaan zetten zodat de (async) afhandeling niet fout gaat

--- a/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
+++ b/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
@@ -1,7 +1,7 @@
+import { createHash } from 'crypto';
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { Response } from '@gemeentenijmegen/apigateway-http';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
-import { createHash } from 'crypto';
 import { authenticate } from '../Shared/authenticate';
 import { ErrorResponse } from '../Shared/ErrorResponse';
 import { logger } from '../Shared/Logger';

--- a/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
+++ b/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { Response } from '@gemeentenijmegen/apigateway-http';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
@@ -36,11 +35,9 @@ export async function handler(event: APIGatewayProxyEventV2) {
 
     // Forward the notification to the queue
     const messageJson = JSON.stringify(notification);
-    const deduplicationId = createHash('sha256').update(messageJson).digest('hex');
     await sqs.send(new SendMessageCommand({
       MessageBody: messageJson,
       QueueUrl: process.env.QUEUE_URL,
-      MessageDeduplicationId: deduplicationId,
       MessageGroupId: process.env.REGISTRATION_SERVICE_ID,
     }));
 

--- a/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
+++ b/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
@@ -1,7 +1,7 @@
-import { createHash } from 'crypto';
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { Response } from '@gemeentenijmegen/apigateway-http';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { createHash } from 'crypto';
 import { authenticate } from '../Shared/authenticate';
 import { ErrorResponse } from '../Shared/ErrorResponse';
 import { logger } from '../Shared/Logger';
@@ -26,6 +26,11 @@ export async function handler(event: APIGatewayProxyEventV2) {
     const ignoreReasons = validateNotification(notification);
     if (ignoreReasons) {
       logger.info('Notification ignored', { ignoreReasons });
+      return Response.ok();
+    }
+
+    // If forwarding is not enabled just respond with ok
+    if (process.env.ENABLE_FORWARDING == 'false') {
       return Response.ok();
     }
 

--- a/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
+++ b/src/services/OpenKlantRegistrationService/NotificationReceiver/receiver.lambda.ts
@@ -38,7 +38,6 @@ export async function handler(event: APIGatewayProxyEventV2) {
     await sqs.send(new SendMessageCommand({
       MessageBody: messageJson,
       QueueUrl: process.env.QUEUE_URL,
-      MessageGroupId: process.env.REGISTRATION_SERVICE_ID,
     }));
 
     return Response.ok();

--- a/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
+++ b/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
@@ -45,12 +45,12 @@ export class OpenKlantRegistrationService extends Construct {
       kmsKey: this.props.key,
       alarmCriticality: this.props.criticality.increase(),
       queueOptions: {
-        fifo: true,
+        fifo: false,
       },
     });
 
     const queue = new Queue(this, 'queue', {
-      fifo: true,
+      fifo: false,
       deadLetterQueue: {
         maxReceiveCount: 5,
         queue: dlq.dlq,

--- a/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
+++ b/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
@@ -118,6 +118,7 @@ export class OpenKlantRegistrationService extends Construct {
         API_KEY_ARN: this.params.authentication.secretArn,
         QUEUE_URL: queue.queueUrl,
         REGISTRATION_SERVICE_ID: id,
+        ENABLE_FORWARDING: openKlantConfig.enabled ? 'true' : 'false',
       },
       logGroup: logs,
       loggingFormat: LoggingFormat.JSON,

--- a/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
+++ b/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
@@ -64,7 +64,7 @@ export class OpenKlantRegistrationService extends Construct {
 
   private setupRegistrationHandler(id: string, queue: Queue) {
 
-    const logs = new LogGroup(this, 'registraiont-handler-logs', {
+    const logs = new LogGroup(this, 'registration-handler-logs', {
       encryptionKey: this.props.key,
       retention: RetentionDays.SIX_MONTHS,
     });

--- a/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
+++ b/src/services/OpenKlantRegistrationService/OpenKlantRegistrationService.ts
@@ -70,7 +70,7 @@ export class OpenKlantRegistrationService extends Construct {
     });
 
     const openKlantConfig = this.props.openKlantRegistrationServiceConfiguration;
-    const service = new RegistrationHandlerFunction(this, 'registraiont-handler', {
+    const service = new RegistrationHandlerFunction(this, 'registration-handler', {
       timeout: Duration.seconds(30),
       description: `Registration handler endpoint for ${id}`,
       environment: {

--- a/src/services/OpenKlantRegistrationService/RegistrationHandler/OpenKlantMapper.ts
+++ b/src/services/OpenKlantRegistrationService/RegistrationHandler/OpenKlantMapper.ts
@@ -10,8 +10,8 @@ import { Rol } from '../Shared/model/Rol';
  */
 export class OpenKlantMapper {
 
-  static readonly TELEFOONNUMMER = 'Telefoon'; // Expected by OMC
-  static readonly EMAIL = 'Email'; // Expected by OMC
+  static readonly TELEFOONNUMMER = 'telefoonnummer'; // Expected by OMC
+  static readonly EMAIL = 'email'; // Expected by OMC
 
   /**
    * Map a rol to a open-klant persoon (subtype of partij)

--- a/src/services/OpenKlantRegistrationService/Shared/model/Partij.ts
+++ b/src/services/OpenKlantRegistrationService/Shared/model/Partij.ts
@@ -76,7 +76,7 @@ export const OpenKlantDigitaalAdresSchema = z.object({
   verstrektDoorBetrokkene: z.union([z.null(), uuidSchema]),
   verstrektDoorPartij: z.union([z.null(), uuidSchema]),
   adres: z.string(),
-  soortDigitaalAdres: z.string(),
+  soortDigitaalAdres: z.enum(['email', 'telefoonnummer', 'overig']),
   omschrijving: z.string(),
 });
 

--- a/src/services/OpenNotificaties.ts
+++ b/src/services/OpenNotificaties.ts
@@ -73,10 +73,6 @@ export class OpenNotificatiesService extends Construct {
   private getEnvironmentConfiguration() {
 
     const cacheHost = this.props.cache.db.attrRedisEndpointAddress + ':' + this.props.cache.db.attrRedisEndpointPort + '/';
-
-    // const trustedOrigins = this.props.alternativeDomainNames?.map(alternative => `https://${alternative}`) ?? [];
-    // trustedOrigins.push(`https://${this.props.hostedzone.zoneName}`);
-
     const trustedDomains = this.props.alternativeDomainNames?.map(a => a) ?? [];
     trustedDomains.push(this.props.hostedzone.zoneName);
 
@@ -272,7 +268,6 @@ export class OpenNotificatiesService extends Construct {
       path: this.props.path,
       options: {
         desiredCount: 1,
-        enableExecuteCommand: true,
       },
     });
     this.setupConnectivity('main', service.connections.securityGroups);

--- a/src/services/OpenNotificaties.ts
+++ b/src/services/OpenNotificaties.ts
@@ -91,7 +91,7 @@ export class OpenNotificatiesService extends Construct {
       ALLOWED_HOSTS: '*',
       CACHE_DEFAULT: cacheHost + this.props.cacheDatabaseIndex,
       CACHE_AXES: cacheHost + this.props.cacheDatabaseIndex,
-      SUBPATH: '/'+this.props.path,
+      SUBPATH: '/' + this.props.path,
       IS_HTTPS: 'yes',
       UWSGI_PORT: this.props.service.port.toString(),
       USE_X_FORWARDED_HOST: 'True',
@@ -221,6 +221,7 @@ export class OpenNotificatiesService extends Construct {
         streamPrefix: 'setup-service',
         logGroup: this.logs,
       }),
+
     });
     this.serviceFactory.attachEphemeralStorage(container, VOLUME_NAME, '/tmp', '/app/log');
 
@@ -271,6 +272,7 @@ export class OpenNotificatiesService extends Construct {
       path: this.props.path,
       options: {
         desiredCount: 1,
+        enableExecuteCommand: true,
       },
     });
     this.setupConnectivity('main', service.connections.securityGroups);

--- a/src/services/OpenNotificaties.ts
+++ b/src/services/OpenNotificaties.ts
@@ -210,7 +210,7 @@ export class OpenNotificatiesService extends Construct {
           OPEN_NOTIFICATIES_IMAGE: this.props.openNotificationsConfiguration.image,
         },
       }),
-      command: ['/setup_configuration.sh'],
+      command: undefined, // Command is defined in Dockerfile
       readonlyRootFilesystem: true,
       essential: true,
       logging: new AwsLogDriver({

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -234,7 +234,6 @@ export class OpenZaakService extends Construct {
       id: 'celery',
       options: {
         desiredCount: 1,
-        enableExecuteCommand: true,
       },
     });
     this.setupConnectivity('celery', service.connections.securityGroups);

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -103,13 +103,12 @@ export class OpenZaakService extends Construct {
       OPENZAAK_DOMAIN: trustedDomains[0],
       OPENZAAK_ORGANIZATION: Statics.organization,
       NOTIF_API_ROOT: `https://${trustedDomains[0]}/open-notificaties/api/v1/`, // TODO remove hardcoded path
+      OPENZAAK_NOTIF_CONFIG_ENABLE: 'True', // Enable the configuration setup for connecting to open-notificaties
 
-      // 11 Feb 2025 - I think this is replaced by setup_configuration new approach (using yaml file)
-      // OPENZAAK_NOTIF_CONFIG_ENABLE: 'True', // Enable the configuration setup for connecting to open-notificaties
       // Somehow this is required aswell...
-      // DEMO_CONFIG_ENABLE: 'False',
-      // DEMO_CLIENT_ID: 'demo-client',
-      // DEMO_SECRET: 'demo-secret',
+      DEMO_CONFIG_ENABLE: 'False',
+      DEMO_CLIENT_ID: 'demo-client',
+      DEMO_SECRET: 'demo-secret',
 
     };
   }

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -211,7 +211,10 @@ export class OpenZaakService extends Construct {
       readonlyRootFilesystem: true,
       essential: true,
       secrets: this.getSecretConfiguration(),
-      environment: this.getEnvironmentConfiguration(),
+      environment: {
+        ...this.getEnvironmentConfiguration(),
+        RUN_SETUP_CONFIG: 'true', // Make sure the setup script can run?
+      },
       logging: new AwsLogDriver({
         streamPrefix: 'logs',
         logGroup: this.logs,

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -224,7 +224,7 @@ export class OpenZaakService extends Construct {
     const service = this.serviceFactory.createService({
       id: 'setup-configuration',
       task: task,
-      path: this.props.path,
+      path: undefined, // Do not connect this service to the internet
       options: {
         desiredCount: 0, // DISABLE BY DEFAULT AND RUN MANUALLY
       },

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -73,7 +73,7 @@ export class OpenZaakService extends Construct {
       ALLOWED_HOSTS: '*',
       CACHE_DEFAULT: cacheHost + this.props.cacheDatabaseIndex,
       CACHE_AXES: cacheHost + this.props.cacheDatabaseIndex,
-      SUBPATH: '/'+this.props.path,
+      SUBPATH: '/' + this.props.path,
       IS_HTTPS: 'True',
       UWSGI_PORT: this.props.service.port.toString(),
 
@@ -234,6 +234,7 @@ export class OpenZaakService extends Construct {
       id: 'celery',
       options: {
         desiredCount: 1,
+        enableExecuteCommand: true,
       },
     });
     this.setupConnectivity('celery', service.connections.securityGroups);

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -140,7 +140,7 @@ export class OpenZaakService extends Construct {
 
   /**
    * Setup the main service (e.g. open-zaak container)
-   * @returns 
+   * @returns
    */
   private setupService() {
     const VOLUME_NAME = 'tmp';
@@ -191,7 +191,7 @@ export class OpenZaakService extends Construct {
   /**
    * This service is disabled by default an can be ran manually to
    * setup the configuration when deploying a new open-zaak.
-   * @returns 
+   * @returns
    */
   private setupConfigurationService() {
     const VOLUME_NAME = 'tmp';
@@ -208,7 +208,7 @@ export class OpenZaakService extends Construct {
       }),
       command: undefined, // Do not set a command as the entrypoint will handle this for us (see Dockerfile)
       readonlyRootFilesystem: true,
-      essential: false, // exit after running
+      essential: true,
       secrets: this.getSecretConfiguration(),
       environment: this.getEnvironmentConfiguration(),
       logging: new AwsLogDriver({
@@ -229,7 +229,7 @@ export class OpenZaakService extends Construct {
         desiredCount: 0, // DISABLE BY DEFAULT AND RUN MANUALLY
       },
     });
-    this.setupConnectivity('main', service.connections.securityGroups);
+    this.setupConnectivity('setup-configuration', service.connections.securityGroups);
     this.allowAccessToSecrets(service.taskDefinition.executionRole!);
     return service;
   }

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -103,12 +103,13 @@ export class OpenZaakService extends Construct {
       OPENZAAK_DOMAIN: trustedDomains[0],
       OPENZAAK_ORGANIZATION: Statics.organization,
       NOTIF_API_ROOT: `https://${trustedDomains[0]}/open-notificaties/api/v1/`, // TODO remove hardcoded path
-      OPENZAAK_NOTIF_CONFIG_ENABLE: 'True', // Enable the configuration setup for connecting to open-notificaties
 
+      // 11 Feb 2025 - I think this is replaced by setup_configuration new approach (using yaml file)
+      // OPENZAAK_NOTIF_CONFIG_ENABLE: 'True', // Enable the configuration setup for connecting to open-notificaties
       // Somehow this is required aswell...
-      DEMO_CONFIG_ENABLE: 'False',
-      DEMO_CLIENT_ID: 'demo-client',
-      DEMO_SECRET: 'demo-secret',
+      // DEMO_CONFIG_ENABLE: 'False',
+      // DEMO_CLIENT_ID: 'demo-client',
+      // DEMO_SECRET: 'demo-secret',
 
     };
   }

--- a/src/services/OpenZaak.ts
+++ b/src/services/OpenZaak.ts
@@ -202,11 +202,15 @@ export class OpenZaakService extends Construct {
 
     // Configuration - initialization container
     const initContainer = task.addContainer('init-config', {
-      image: ContainerImage.fromAsset('./src/containers/open-zaak/', {
-        buildArgs: {
-          OPEN_ZAAK_IMAGE: this.props.openZaakConfiguration.image,
-        },
-      }),
+      image: ContainerImage.fromRegistry(this.props.openZaakConfiguration.image),
+
+      // TODO enable this later, current release is does not yet use the yaml configuration (open-notifictions does) (13 Feb 2025)
+      // image: ContainerImage.fromAsset('./src/containers/open-zaak/', {
+      //   buildArgs: {
+      //     OPEN_ZAAK_IMAGE: this.props.openZaakConfiguration.image,
+      //   },
+      // }),
+
       command: undefined, // Do not set a command as the entrypoint will handle this for us (see Dockerfile)
       readonlyRootFilesystem: true,
       essential: true,


### PR DESCRIPTION
- Run setup_configuration script in separate ECS service for open-zaak en open-notificaties
- Open-notificaties now uses the yaml configuration file and therefore builds a separate container
- Open-zaak does not yet use the yaml configuration in the latest release (1.17.0) 
- As we now build containers in the pipeline, we need dockerhub credentials in the pipeline
- Update OpenKlantRegistration service to be compliant with new open-klant API
- Change OpenKlantRegistration queue from fifo to standaard (no need to keep order)