### PR TITLE
feat: move configuration services to scheduled ECS tasks

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,28 @@
+# Deployment info
+De meeste infra wordt automatisch gegenereerd door cloudformation.
+We kunnen alleen niet alles helemaal automatiseren door de configuratie van de containers.
+Daarom is er voor elke van de volgende services een scheduled ECS Task aangemaakt:
+- Objects
+- Objecttypes
+- OpenKlant
+- OpenNotificaties
+- OpenZaak
+Dit zijn allemaal containers van Maykin. Deze ECS Tasks hebben een cron ingesteld op 2020 bij deployment. 
+Deze kan hantmatig aangepast worden (in de console...) om de configuratie taak te schedulen.
+
+
+Voor een aantal containers is dit beperkt tot het maken van een superuser door het volgende commando te draaien:
+```
+python src/manage.py createsuperuser
+```
+Dit gaat om de containers: objects, objecttypes en OpenKlant
+
+## Open notificaties
+Voor OpenNotificaties is er een nieuwe opzet in gebruik (iets met een configuratie file). 
+[Zie hier voor een voorbeeld](https://github.com/open-zaak/open-notificaties/blob/main/docker/setup_configuration/data.yaml). 
+Ik heb dit nog niet aan de praat gekregen, de configuratie wordt daarom met de hand gedaan.
+
+
+## Open zaak
+Open zaak maakt nog niet gebruik van dezelfde configuratie file als open notificaties. 
+Hiervoor wordt het setup_configuration script in de container gedraaid.

--- a/src/services/Objects.ts
+++ b/src/services/Objects.ts
@@ -213,7 +213,7 @@ export class ObjectsService extends Construct {
       '/app/log',
       '/app/tmp/celery_worker_heartbeat',
       '/app/tmp/celery_worker_ready',
-    ]
+    ];
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],
     });

--- a/src/services/Objects.ts
+++ b/src/services/Objects.ts
@@ -211,8 +211,8 @@ export class ObjectsService extends Construct {
       '/tmp',
       '/app/tmp',
       '/app/log',
-      'app/tmp/celery_worker_heartbeat',
-      'app/tmp/celery_worker_ready',
+      '/app/tmp/celery_worker_heartbeat',
+      '/app/tmp/celery_worker_ready',
     ]
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],

--- a/src/services/Objects.ts
+++ b/src/services/Objects.ts
@@ -192,7 +192,7 @@ export class ObjectsService extends Construct {
       schedule: Schedule.cron({
         year: '2020',
       }),
-      description: 'Rule to run setup configuration task just once (manually)',
+      description: 'Rule to run setup configuration for objects-api (manually)',
     });
     const ecsTask = new EcsTask({
       cluster: this.props.service.cluster,
@@ -207,6 +207,13 @@ export class ObjectsService extends Construct {
 
   private setupCeleryService() {
     const VOLUME_NAME = 'temp';
+    const WITABLE_DIRS = [
+      '/tmp',
+      '/app/tmp',
+      '/app/log',
+      'app/tmp/celery_worker_heartbeat',
+      'app/tmp/celery_worker_ready',
+    ]
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],
     });
@@ -227,9 +234,9 @@ export class ObjectsService extends Construct {
       }),
       command: ['/celery_worker.sh'],
     });
-    this.serviceFactory.attachEphemeralStorage(container, VOLUME_NAME, '/tmp', '/app/tmp', '/app/log');
+    this.serviceFactory.attachEphemeralStorage(container, VOLUME_NAME, ...WITABLE_DIRS);
 
-    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, container, '/tmp', '/app/tmp', '/app/log');
+    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, container, ...WITABLE_DIRS);
 
     const service = this.serviceFactory.createService({
       task,

--- a/src/services/Objects.ts
+++ b/src/services/Objects.ts
@@ -211,8 +211,6 @@ export class ObjectsService extends Construct {
       '/tmp',
       '/app/tmp',
       '/app/log',
-      '/app/tmp/celery_worker_heartbeat',
-      '/app/tmp/celery_worker_ready',
     ];
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],

--- a/src/services/Objecttypes.ts
+++ b/src/services/Objecttypes.ts
@@ -142,7 +142,7 @@ export class ObjecttypesService extends Construct {
       schedule: Schedule.cron({
         year: '2020',
       }),
-      description: 'Rule to run setup configuration task just once (manually)',
+      description: 'Rule to run setup configuration for objecttypes-api (manually)',
     });
     const ecsTask = new EcsTask({
       cluster: this.props.service.cluster,

--- a/src/services/OpenNotificaties.ts
+++ b/src/services/OpenNotificaties.ts
@@ -298,8 +298,6 @@ export class OpenNotificatiesService extends Construct {
       '/tmp',
       '/app/tmp',
       '/app/log',
-      '/app/tmp/celery_worker_heartbeat',
-      '/app/tmp/celery_worker_ready',
     ];
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],

--- a/src/services/OpenNotificaties.ts
+++ b/src/services/OpenNotificaties.ts
@@ -294,6 +294,13 @@ export class OpenNotificatiesService extends Construct {
 
   private setupCeleryService() {
     const VOLUME_NAME = 'tempcelery';
+    const WITABLE_DIRS = [
+      '/tmp',
+      '/app/tmp',
+      '/app/log',
+      '/app/tmp/celery_worker_heartbeat',
+      '/app/tmp/celery_worker_ready',
+    ]
     const task = this.serviceFactory.createTaskDefinition('celery', {
       volumes: [{ name: VOLUME_NAME }],
     });
@@ -313,8 +320,8 @@ export class OpenNotificatiesService extends Construct {
       }),
       command: ['/celery_worker.sh'],
     });
-    this.serviceFactory.attachEphemeralStorage(celeryContainer, VOLUME_NAME, '/tmp', '/app/log');
-    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, celeryContainer, '/tmp', '/app/log');
+    this.serviceFactory.attachEphemeralStorage(celeryContainer, VOLUME_NAME, ...WITABLE_DIRS);
+    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, celeryContainer, ...WITABLE_DIRS);
     const service = this.serviceFactory.createService({
       task,
       path: undefined, // Not exposed service


### PR DESCRIPTION
- Moved configuration services (ran manually) to schedules ECS tasks
- Make sure celery containers have sufficient time to start