### PR TITLE
chore: upgrade postgres engine

### DIFF
--- a/src/constructs/Database.ts
+++ b/src/constructs/Database.ts
@@ -28,8 +28,9 @@ export class Database extends Construct {
 
     this.db = new rds.DatabaseInstance(this, 'db-instance', {
       engine: rds.DatabaseInstanceEngine.postgres({
-        version: rds.PostgresEngineVersion.VER_16_4,
+        version: rds.PostgresEngineVersion.VER_17_5,
       }),
+      allowMajorVersionUpgrade: true, // Note: required to be able to upgrade Postgres
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO), // Smallest instance possible to start with
       credentials: {
         username: props.databaseSecret.secretValueFromJson('username').toString(),


### PR DESCRIPTION
Fixes #485 

> If your backup retention period is greater than 0, Amazon RDS takes two DB snapshots during the upgrade process. The first DB snapshot is of the database before any upgrade changes have been made. If the upgrade fails for your databases, you can restore this snapshot to create a database running the old version. The second DB snapshot is taken after the upgrade completes. These DB snapshots are deleted automatically once the backup retention period expires.

Backup retention period settings:
- Dev: 0
- Accp: 10
- Prod: 35