### PR TITLE
chore: Rollback open-object to 3.6.0

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -180,7 +180,7 @@ const EnvironmentConfigurations: { [key: string]: Configuration } = {
       useNewDatabase: true,
     },
     objectsService: {
-      image: 'maykinmedia/open-object:4.0.0',
+      image: 'maykinmedia/open-object:3.6.0',
       logLevel: 'DEBUG',
       debug: true,
       useNewDatabase: true,


### PR DESCRIPTION
Migration script for 4.0.0 fails (camelCase is replaced with snake_case) in JSONSchema.