### PR TITLE
feat: migration task

### DIFF
--- a/docs/Operations/Migratie stappen productie open-object.md
+++ b/docs/Operations/Migratie stappen productie open-object.md
@@ -1,0 +1,46 @@
+# Migratie stappen productie open-object
+
+## Dag 1. Database migratie
+
+- OpenForms token uitzetten
+- Uitzetten services
+- Drop & opnieuw aanmaken objects-database via lambda (na gefaalde upgrade).
+- Scripts hieronder uitvoeren
+- CDK deployment met nieuwe DB flag voor open-objecten
+- OpenForms token fixen
+
+```bash
+sudo dnf remove postgresql16
+sudo dnf install postgresql17
+export ENDPOINT=prod-db-server.eu-central-1.rds.amazonaws.com
+pg_dump -h $ENDPOINT -U mijn_services -d objects -Fc -f objects.dump
+psql -h $ENDPOINT -U mijn_services -d objects-database -c "CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;"
+pg_restore -h $ENDPOINT -U mijn_services -d objects-database --no-owner --role=objects-database -F c objects.dump
+```
+
+## Dag 2. Upgrade naar 3.6.1
+- Token OpenForms vervangen
+- Handmatig nieuwe taskdefinition aanmaken met 3.6.1 ipv 3.0.0
+- Service uitzetten (celery en web)
+- Dump database maken en in S3 zetten.
+- Taak starten (handmatig) met override commando `sleep,infinity` (comma moet daar staan).
+- `python src/manage.py migrate` draaien
+- Handmatig ECS services aanpassen (celery & web) naar nieuwe taskdefinitions
+- Desired task count ophogen naar 1
+- Deployment vanuit CDK met nieuwe versie nummers om de boel weer consistent te maken.
+- Token OpenForms fixen als alles weer werkt
+
+Getest:
+- Handmatig draaien van de taak en migratie script runnen
+- Service update na handmatig aanpassen wanneer desired task count 0 is, zorgt voor starten nieuwe alleen nieuwe task definitions wanneer desired task count weer wordt opgehoogd.
+
+
+## Dag 3. Upgrade naar 4.1.0
+- Zelfde stappen als dag 2
+Daarnaast:
+- Import commando draaien voor uitzetten container
+- Checken in DB of imports zijn geslaagd.
+
+Let op: Externe afhankelijkheden
+- Open Forms
+- ESF (op ESB)

--- a/src/ConfigurationInterfaces.ts
+++ b/src/ConfigurationInterfaces.ts
@@ -291,6 +291,18 @@ export interface ObjectsConfiguration extends MainTaskSizeConfiguration, CeleryT
    */
   image: string;
   /**
+   * Image (usually a newer version than `image`) used for the standalone
+   * database migration task definition. When set, a CDK-owned `objects-migrate`
+   * task definition is created that runs `python src/manage.py migrate` off the
+   * load balancer, to be executed via the `src/django-migrate` runner during a
+   * maintenance window. This lets the migration run against the new version
+   * ahead of (and independently from) moving the service to that version.
+   *
+   * Leave unset outside of a migration window; no migration task is created.
+   * @default - no migration task definition is created
+   */
+  migrationImage?: string;
+  /**
    * Log level for the container
    */
   logLevel: 'DEBUG' | 'INFO' | 'ERROR';

--- a/src/configuration/development.ts
+++ b/src/configuration/development.ts
@@ -86,6 +86,7 @@ export const development: Configuration = {
   },
   objectsService: {
     image: 'maykinmedia/open-object:4.0.0',
+    migrationImage: 'maykinmedia/open-object:4.0.0',
     logLevel: 'DEBUG',
     debug: true,
     useNewDatabase: true,

--- a/src/django-migrate/run-objects-migrate.sh
+++ b/src/django-migrate/run-objects-migrate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Manually run the standalone objects migration task in dev.
+#
+# It resolves the CDK stack outputs by their (stable) Description strings, so you
+# do NOT need to know the generated stack name or output keys. It does NOT scale
+# any service down and does NOT snapshot anything — this is the safe, idempotent
+# "does the task def even work" check against an already-migrated dev DB.
+#
+# Usage:
+#   bash /tmp/run-objects-migrate.sh          # print the resolved run-task command
+#   bash /tmp/run-objects-migrate.sh run      # actually run it
+#
+# Requires: awscli v2 + jq, with credentials for the dev account already active.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-eu-central-1}"
+
+echo "Resolving migration task outputs in region ${REGION}..." >&2
+OUTPUTS="$(aws cloudformation describe-stacks --region "${REGION}" \
+  --query 'Stacks[].Outputs[]' --output json)"
+
+lookup() {
+  # $1 = the CfnOutput Description to match
+  echo "${OUTPUTS}" | jq -r --arg d "$1" '[.[] | select(.Description==$d)][0].OutputValue // empty'
+}
+
+CLUSTER="$(lookup 'django-migrate ECS_CLUSTER')"
+TASKDEF="$(lookup 'django-migrate MIGRATION_TASK_DEFINITION (family:revision)')"
+SUBNETS="$(lookup 'django-migrate SUBNETS')"
+SECURITY_GROUPS="$(lookup 'django-migrate SECURITY_GROUPS')"
+
+missing=0
+for pair in "ECS_CLUSTER=${CLUSTER}" "TASK_DEFINITION=${TASKDEF}" \
+            "SUBNETS=${SUBNETS}" "SECURITY_GROUPS=${SECURITY_GROUPS}"; do
+  if [ -z "${pair#*=}" ]; then
+    echo "ERROR: could not resolve ${pair%%=*} from stack outputs." >&2
+    missing=1
+  fi
+done
+[ "${missing}" -eq 0 ] || { echo "Is the migrationImage-enabled stack deployed to this account/region?" >&2; exit 1; }
+
+echo "  cluster:         ${CLUSTER}" >&2
+echo "  task definition: ${TASKDEF}" >&2
+echo "  subnets:         ${SUBNETS}" >&2
+echo "  security groups: ${SECURITY_GROUPS}" >&2
+echo >&2
+
+# subnets output is already comma-separated; wrap both lists in [ ] for awsvpc.
+NETWORK_CONFIG="awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SECURITY_GROUPS}],assignPublicIp=DISABLED}"
+
+RUN_TASK=(aws ecs run-task
+  --region "${REGION}"
+  --cluster "${CLUSTER}"
+  --task-definition "${TASKDEF}"
+  --launch-type FARGATE
+  --started-by "manual-migrate-verify"
+  --network-configuration "${NETWORK_CONFIG}")
+
+if [ "${1:-}" = "run" ]; then
+  echo "Running migration task..." >&2
+  "${RUN_TASK[@]}"
+  echo >&2
+  echo "Task started. Watch it in the ECS console (or 'aws ecs describe-tasks')." >&2
+  echo "Success = the 'migrate' container exits 0 and its log shows 'No migrations to apply.'" >&2
+else
+  echo "# Dry print only — re-run with 'run' to execute:" >&2
+  printf '%q ' "${RUN_TASK[@]}"
+  echo
+fi

--- a/src/django-migrate/run-objects-migrate.sh
+++ b/src/django-migrate/run-objects-migrate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Manually run the standalone objects migration task in dev.
+# Manually run (and watch) the standalone objects migration task in dev.
 #
 # It resolves the CDK stack outputs by their (stable) Description strings, so you
 # do NOT need to know the generated stack name or output keys. It does NOT scale
@@ -8,14 +8,18 @@
 # "does the task def even work" check against an already-migrated dev DB.
 #
 # Usage:
-#   bash /tmp/run-objects-migrate.sh          # print the resolved run-task command
-#   bash /tmp/run-objects-migrate.sh run      # actually run it
+#   bash src/django-migrate/run-objects-migrate.sh          # print the run-task command, run nothing
+#   bash src/django-migrate/run-objects-migrate.sh run      # run it, auto-tail logs, report exit code
+#   bash src/django-migrate/run-objects-migrate.sh logs ID  # tail an already-running task (id or ARN)
 #
 # Requires: awscli v2 + jq, with credentials for the dev account already active.
 
 set -euo pipefail
 
 REGION="${AWS_REGION:-eu-central-1}"
+
+# awslogs stream name = <streamPrefix>/<containerName>/<taskId>; both are "migrate".
+STREAM_PREFIX="migrate/migrate"
 
 echo "Resolving migration task outputs in region ${REGION}..." >&2
 OUTPUTS="$(aws cloudformation describe-stacks --region "${REGION}" \
@@ -30,6 +34,26 @@ CLUSTER="$(lookup 'django-migrate ECS_CLUSTER')"
 TASKDEF="$(lookup 'django-migrate MIGRATION_TASK_DEFINITION (family:revision)')"
 SUBNETS="$(lookup 'django-migrate SUBNETS')"
 SECURITY_GROUPS="$(lookup 'django-migrate SECURITY_GROUPS')"
+LOG_GROUP="$(lookup 'CloudWatch log group for the migration task')"
+
+# Tail the migrate container's logs for a given task id until interrupted.
+tail_logs() {
+  local task_id="${1##*/}"   # accept a full task ARN too
+  if [ -z "${LOG_GROUP}" ]; then
+    echo "WARN: could not resolve the log group output; skipping log tail." >&2
+    return 0
+  fi
+  echo "Tailing logs: ${LOG_GROUP}  stream ${STREAM_PREFIX}/${task_id}" >&2
+  aws logs tail "${LOG_GROUP}" --region "${REGION}" --follow --since 5m \
+    --format short --log-stream-name-prefix "${STREAM_PREFIX}/${task_id}"
+}
+
+# Subcommand: just tail an already-running task's logs.
+if [ "${1:-}" = "logs" ]; then
+  [ -n "${2:-}" ] || { echo "Usage: $0 logs <taskId|taskArn>" >&2; exit 1; }
+  tail_logs "$2"
+  exit 0
+fi
 
 missing=0
 for pair in "ECS_CLUSTER=${CLUSTER}" "TASK_DEFINITION=${TASKDEF}" \
@@ -45,6 +69,7 @@ echo "  cluster:         ${CLUSTER}" >&2
 echo "  task definition: ${TASKDEF}" >&2
 echo "  subnets:         ${SUBNETS}" >&2
 echo "  security groups: ${SECURITY_GROUPS}" >&2
+echo "  log group:       ${LOG_GROUP:-<not found>}" >&2
 echo >&2
 
 # subnets output is already comma-separated; wrap both lists in [ ] for awsvpc.
@@ -58,14 +83,54 @@ RUN_TASK=(aws ecs run-task
   --started-by "manual-migrate-verify"
   --network-configuration "${NETWORK_CONFIG}")
 
-if [ "${1:-}" = "run" ]; then
-  echo "Running migration task..." >&2
-  "${RUN_TASK[@]}"
-  echo >&2
-  echo "Task started. Watch it in the ECS console (or 'aws ecs describe-tasks')." >&2
-  echo "Success = the 'migrate' container exits 0 and its log shows 'No migrations to apply.'" >&2
-else
+if [ "${1:-}" != "run" ]; then
   echo "# Dry print only — re-run with 'run' to execute:" >&2
   printf '%q ' "${RUN_TASK[@]}"
   echo
+  exit 0
+fi
+
+echo "Running migration task..." >&2
+TASK_JSON="$("${RUN_TASK[@]}")"
+
+if [ "$(echo "${TASK_JSON}" | jq -r '.failures | length')" != "0" ]; then
+  echo "ERROR: run-task returned failures:" >&2
+  echo "${TASK_JSON}" | jq '.failures' >&2
+  exit 1
+fi
+
+TASK_ARN="$(echo "${TASK_JSON}" | jq -r '.tasks[0].taskArn')"
+TASK_ID="${TASK_ARN##*/}"
+echo "Task started: ${TASK_ARN}" >&2
+echo >&2
+
+# Auto-tail: follow logs in the background, stop the tail once the task stops.
+LOGS_PID=""
+if [ -n "${LOG_GROUP}" ]; then
+  tail_logs "${TASK_ID}" &
+  LOGS_PID=$!
+fi
+cleanup() { [ -n "${LOGS_PID}" ] && kill "${LOGS_PID}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "Waiting for the task to stop..." >&2
+aws ecs wait tasks-stopped --region "${REGION}" --cluster "${CLUSTER}" --tasks "${TASK_ARN}" || true
+
+sleep 3            # let the last log lines flush
+cleanup; trap - EXIT
+echo >&2
+
+DESC="$(aws ecs describe-tasks --region "${REGION}" --cluster "${CLUSTER}" --tasks "${TASK_ARN}")"
+EXIT_CODE="$(echo "${DESC}" | jq -r '.tasks[0].containers[] | select(.name=="migrate") | .exitCode // "none"')"
+STOP_REASON="$(echo "${DESC}" | jq -r '.tasks[0].stoppedReason // "unknown"')"
+
+echo "----------------------------------------" >&2
+echo "migrate exitCode:  ${EXIT_CODE}" >&2
+echo "stoppedReason:     ${STOP_REASON}" >&2
+if [ "${EXIT_CODE}" = "0" ]; then
+  echo "✅ migrate exited 0 — expected 'No migrations to apply.' above." >&2
+  exit 0
+else
+  echo "❌ migrate did not exit 0. Re-tail with: $0 logs ${TASK_ID}" >&2
+  exit 1
 fi

--- a/src/services/Objects.ts
+++ b/src/services/Objects.ts
@@ -1,6 +1,6 @@
-import { Duration, Token } from 'aws-cdk-lib';
-import { ISecurityGroup, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { AwsLogDriver, ContainerImage, Protocol, Secret } from 'aws-cdk-lib/aws-ecs';
+import { CfnOutput, Duration, Fn, Token } from 'aws-cdk-lib';
+import { ISecurityGroup, Port, SecurityGroup, SubnetType } from 'aws-cdk-lib/aws-ec2';
+import { AwsLogDriver, ContainerImage, FargateService, Protocol, Secret, TaskDefinition } from 'aws-cdk-lib/aws-ecs';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -61,8 +61,9 @@ export class ObjectsService extends Construct {
       },
     });
 
-    this.setupService();
-    this.setupCeleryService();
+    const mainService = this.setupService();
+    const celeryService = this.setupCeleryService();
+    this.setupMigrationTask(mainService, celeryService);
   }
 
   private getEnvironmentConfiguration() {
@@ -258,6 +259,108 @@ export class ObjectsService extends Construct {
     this.setupConnectivity('celery', service.connections.securityGroups);
     this.allowAccessToSecrets(service.taskDefinition.executionRole!);
     ECSServiceUtils.allowExecutingCommands(task);
+    return service;
+  }
+
+  /**
+   * Standalone, CDK-owned migration task definition. Runs `manage.py migrate`
+   * off the load balancer (no ECS Service, no ALB, no target group), to be
+   * invoked with `aws ecs run-task` by the `src/django-migrate` runner during a
+   * maintenance window.
+   *
+   * Only created when `migrationImage` is configured, so it can be pinned to the
+   * new version independently of the running service. Emits the values the
+   * runner's `.env` needs as stack outputs.
+   */
+  private setupMigrationTask(mainService: FargateService, celeryService: FargateService) {
+    const migrationImage = this.props.serviceConfiguration.migrationImage;
+    if (!migrationImage) {
+      return;
+    }
+
+    const VOLUME_NAME = 'tmp';
+    const CONTAINER_NAME = 'migrate';
+    const WRITABLE_DIRS = ['/tmp', '/app/log'];
+
+    const task = this.serviceFactory.createTaskDefinition('migrate', {
+      family: `${Statics.projectName}-objects-migrate`,
+      volumes: [{ name: VOLUME_NAME }],
+      cpu: this.props.serviceConfiguration.taskSize?.cpu ?? '256',
+      memoryMiB: this.props.serviceConfiguration.taskSize?.memory ?? '512',
+    });
+
+    const container = task.addContainer(CONTAINER_NAME, {
+      image: ContainerImage.fromRegistry(migrationImage, {
+        credentials: this.props.dockerhubCredentials,
+      }),
+      command: ['python', 'src/manage.py', 'migrate', '--noinput'],
+      readonlyRootFilesystem: false,
+      secrets: this.getSecretConfiguration(),
+      environment: this.getEnvironmentConfiguration(),
+      logging: new AwsLogDriver({
+        streamPrefix: 'migrate',
+        logGroup: this.logs,
+      }),
+    });
+    this.serviceFactory.attachEphemeralStorage(container, VOLUME_NAME, ...WRITABLE_DIRS);
+    this.serviceFactory.setupWritableVolume(VOLUME_NAME, task, this.logs, container, ...WRITABLE_DIRS);
+
+    // No ECS Service is created, so no security group exists yet. Create one and
+    // wire it to the database + cache exactly like the running service's SG, so
+    // the operator can hand it to `run-task`.
+    const migrationSecurityGroup = new SecurityGroup(this, 'migrate-security-group', {
+      vpc: this.props.service.cluster.vpc,
+      description: 'Objects standalone migration task',
+      allowAllOutbound: true,
+    });
+    this.setupConnectivity('migrate', [migrationSecurityGroup]);
+
+    this.allowAccessToSecrets(task.executionRole!);
+    ECSServiceUtils.allowExecutingCommands(task);
+
+    this.migrationTaskOutputs(task, CONTAINER_NAME, migrationSecurityGroup, [mainService, celeryService]);
+  }
+
+  /**
+   * Emit everything the `src/django-migrate` runner's `.env` needs, so the
+   * operator does not have to hunt through the console. See
+   * `src/django-migrate/.env.example`.
+   */
+  private migrationTaskOutputs(task: TaskDefinition, containerName: string, securityGroup: ISecurityGroup, services: FargateService[]) {
+    const subnetIds = this.props.service.cluster.vpc.selectSubnets({
+      subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+    }).subnetIds;
+
+    new CfnOutput(this, 'migrate-cluster', {
+      value: this.props.service.cluster.clusterName,
+      description: 'django-migrate ECS_CLUSTER',
+    });
+    // Every service sharing the schema must be scaled to 0 before migrating.
+    new CfnOutput(this, 'migrate-services', {
+      value: services.map(service => service.serviceName).join(','),
+      description: 'django-migrate ECS_SERVICE (comma-separated, scale all to 0)',
+    });
+    // ARN includes the exact family:revision to pin as MIGRATION_TASK_DEFINITION.
+    new CfnOutput(this, 'migrate-taskdefinition', {
+      value: task.taskDefinitionArn,
+      description: 'django-migrate MIGRATION_TASK_DEFINITION (family:revision)',
+    });
+    new CfnOutput(this, 'migrate-container', {
+      value: containerName,
+      description: 'django-migrate MIGRATION_CONTAINER_NAME',
+    });
+    new CfnOutput(this, 'migrate-subnets', {
+      value: Fn.join(',', subnetIds),
+      description: 'django-migrate SUBNETS',
+    });
+    new CfnOutput(this, 'migrate-security-groups', {
+      value: securityGroup.securityGroupId,
+      description: 'django-migrate SECURITY_GROUPS',
+    });
+    new CfnOutput(this, 'migrate-log-group', {
+      value: this.logs.logGroupName,
+      description: 'CloudWatch log group for the migration task',
+    });
   }
 
   private logGroup() {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1,0 +1,118 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { VpcLink } from 'aws-cdk-lib/aws-apigatewayv2';
+import { SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Cluster } from 'aws-cdk-lib/aws-ecs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { HostedZone } from 'aws-cdk-lib/aws-route53';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { PrivateDnsNamespace } from 'aws-cdk-lib/aws-servicediscovery';
+import { ObjectsConfiguration } from '../src/ConfigurationInterfaces';
+import { ServiceLoadBalancer } from '../src/constructs/LoadBalancer';
+import { CacheDatabase } from '../src/constructs/Redis';
+import { ObjectsService } from '../src/services/Objects';
+
+const MIGRATION_FAMILY = 'mijn-services-objects-migrate';
+
+/**
+ * Stand up an ObjectsService with a minimal platform (just the pieces the
+ * service consumes) and return the synthesized template.
+ */
+function synthObjects(serviceConfiguration: ObjectsConfiguration): Template {
+  const app = new App();
+  const stack = new Stack(app, 'test-stack', {
+    env: { account: '123456789012', region: 'eu-central-1' },
+  });
+
+  const vpc = new Vpc(stack, 'vpc');
+  const hostedzone = HostedZone.fromHostedZoneAttributes(stack, 'hostedzone', {
+    hostedZoneId: 'Z0123456789ABCDEFGHIJ',
+    zoneName: 'example.com',
+  });
+
+  const namespace = new PrivateDnsNamespace(stack, 'namespace', {
+    name: 'mijn-services.local',
+    vpc,
+  });
+  const vpcLinkSecurityGroup = new SecurityGroup(stack, 'vpc-link-sg', { vpc });
+  const vpcLink = new VpcLink(stack, 'vpc-link', { vpc, securityGroups: [vpcLinkSecurityGroup] });
+  const cluster = new Cluster(stack, 'cluster', { vpc });
+  const loadbalancer = new ServiceLoadBalancer(stack, 'lb', { vpc, hostedzone });
+  const cache = new CacheDatabase(stack, 'cache', { vpc });
+
+  new ObjectsService(stack, 'objects', {
+    cache,
+    cacheDatabaseIndex: 9,
+    cacheDatabaseIndexCelery: 10,
+    hostedzone,
+    path: 'objects',
+    key: new Key(stack, 'key'),
+    dockerhubCredentials: new Secret(stack, 'dockerhub'),
+    serviceConfiguration,
+    service: {
+      cluster,
+      link: vpcLink,
+      namespace,
+      loadbalancer,
+      vpcLinkSecurityGroup,
+      port: 8000,
+    },
+  });
+
+  return Template.fromStack(stack);
+}
+
+const baseConfiguration: ObjectsConfiguration = {
+  image: 'maykinmedia/objects-api:3.0.0',
+  logLevel: 'INFO',
+};
+
+test('No migration task definition is created without a migrationImage', () => {
+  const template = synthObjects(baseConfiguration);
+  template.resourcePropertiesCountIs('AWS::ECS::TaskDefinition', {
+    Family: MIGRATION_FAMILY,
+  }, 0);
+});
+
+test('A standalone migration task definition is created when migrationImage is set', () => {
+  const template = synthObjects({
+    ...baseConfiguration,
+    migrationImage: 'maykinmedia/objects-api:3.6.1',
+  });
+
+  // Pinned to the migration image (not the service image) and runs migrate.
+  template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+    Family: MIGRATION_FAMILY,
+    ContainerDefinitions: Match.arrayWith([
+      Match.objectLike({
+        Name: 'migrate',
+        Image: 'maykinmedia/objects-api:3.6.1',
+        Command: ['python', 'src/manage.py', 'migrate', '--noinput'],
+      }),
+    ]),
+  });
+});
+
+test('The migration task definition is not attached to any ECS service', () => {
+  const template = synthObjects({
+    ...baseConfiguration,
+    migrationImage: 'maykinmedia/objects-api:3.6.1',
+  });
+
+  // Only the main + celery services exist; nothing wires up the migrate task.
+  const services = template.findResources('AWS::ECS::Service');
+  expect(Object.keys(services)).toHaveLength(2);
+});
+
+test('Migration outputs expose both services to scale down', () => {
+  const template = synthObjects({
+    ...baseConfiguration,
+    migrationImage: 'maykinmedia/objects-api:3.6.1',
+  });
+
+  // The web + celery service names, comma-joined, for the runner's ECS_SERVICE.
+  template.hasOutput('*', {
+    Description: 'django-migrate ECS_SERVICE (comma-separated, scale all to 0)',
+    Value: Match.anyValue(),
+  });
+});


### PR DESCRIPTION
This introduces the ability to create a standalone ECS task
definition specifically for running database migrations. This allows
running migrations using a specific image version independently of the
main service version.

- Adds `migrationImage` option to `ObjectsConfiguration`.
- Implements `setupMigrationTask` in `ObjectsService` to create an ECS
  task definition that runs `manage.py migrate`.
- Adds `migrationTaskOutputs` to emit necessary environment variables
  and identifiers (cluster, services, task definition, etc.) as CloudWatch
  stack outputs for easier use with external runners.
- Creates a new security group for the migration task to ensure network
  connectivity to the database and cache.
- Adds unit tests in `test/objects.test.ts` to verify that the migration
  task is only created when `migrationImage` is provided and that it
  contains the correct configuration.

A bash script to execute this task is provided as well:
This adds a new bash script, `run-objects-migrate.sh`, which allows developers
to manually trigger a standalone Django migration task in an environment.

Auth your CLI (ep required)
Dry-run

```bash
bash run-objects-migrate.sh
```
Outputs params (cluster/SG etc.)

```
bash run-objects-migrate.sh run
```

Starts the migrate task: Standalone task, using the migrate image, connected to the same DB as the main task.
```

Note: The rest of the steps (turning off all services etc.) is still required.

- **docs: steps for prod migration**
- **feat: add standalone database migration task**
- **feat: add script to run django migrations manually**