### PR TITLE
chore: Prepare prod migration image

### DIFF
--- a/src/configuration/acceptance.ts
+++ b/src/configuration/acceptance.ts
@@ -49,6 +49,7 @@ export const acceptance: Configuration = {
   },
   objectsService: {
     image: 'maykinmedia/open-object:4.1.0',
+    migrationImage: 'maykinmedia/open-object:4.1.0',
     logLevel: 'DEBUG',
     debug: true,
     useNewDatabase: true,

--- a/src/configuration/development.ts
+++ b/src/configuration/development.ts
@@ -86,7 +86,7 @@ export const development: Configuration = {
   },
   objectsService: {
     image: 'maykinmedia/open-object:4.0.0',
-    migrationImage: 'maykinmedia/open-object:4.0.0',
+    migrationImage: 'maykinmedia/open-object:4.1.0',
     logLevel: 'DEBUG',
     debug: true,
     useNewDatabase: true,

--- a/src/configuration/development.ts
+++ b/src/configuration/development.ts
@@ -85,7 +85,7 @@ export const development: Configuration = {
     useNewDatabase: true,
   },
   objectsService: {
-    image: 'maykinmedia/open-object:4.0.0',
+    image: 'maykinmedia/open-object:4.1.0',
     migrationImage: 'maykinmedia/open-object:4.1.0',
     logLevel: 'DEBUG',
     debug: true,

--- a/src/configuration/main.ts
+++ b/src/configuration/main.ts
@@ -49,6 +49,7 @@ export const main: Configuration = {
   },
   objectsService: {
     image: 'maykinmedia/objects-api:3.0.0',
+    migrationImage: 'maykinmedia/open-object:3.6.1',
     logLevel: 'INFO',
     debug: false,
     taskSize: {


### PR DESCRIPTION
Adds a migration task to ECS, which does not run (not connected to any service. To run, CLI login to the account (with EP permissions) and run
```
bash src/django-migrate/run-objects-migrate.sh
```

After dyrun, run migrations with
```
bash src/django-migrate/run-objects-migrate.sh run
```

Note: This is part of the migration plan. DB backup, turning off services etc. are NOT automated and must be done before running this.